### PR TITLE
Image feature matching

### DIFF
--- a/yagokoro_recognition/CMakeLists.txt
+++ b/yagokoro_recognition/CMakeLists.txt
@@ -16,4 +16,4 @@ add_library(image_feature_matching src/image_feature_matching.cpp)
 target_link_libraries(image_feature_matching ${catkin_LIBRARIES})
 
 add_executable(feature_extraction src/feature_extraction.cpp)
-target_link_libraries(feature_extraction ${catkin_LIBRARIES})
+target_link_libraries(feature_extraction image_feature_matching ${catkin_LIBRARIES})

--- a/yagokoro_recognition/CMakeLists.txt
+++ b/yagokoro_recognition/CMakeLists.txt
@@ -12,5 +12,8 @@ catkin_package(
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
+add_library(image_feature_matching src/image_feature_matching.cpp)
+target_link_libraries(image_feature_matching ${catkin_LIBRARIES})
+
 add_executable(feature_extraction src/feature_extraction.cpp)
 target_link_libraries(feature_extraction ${catkin_LIBRARIES})

--- a/yagokoro_recognition/include/yagokoro_recognition/feature_extraction.hpp
+++ b/yagokoro_recognition/include/yagokoro_recognition/feature_extraction.hpp
@@ -16,10 +16,7 @@
 #include <cv_bridge/cv_bridge.h>
 #include <sensor_msgs/image_encodings.h>
 
-#include <opencv2/core/core.hpp>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/features2d/features2d.hpp>
-#include <opencv2/legacy/legacy.hpp>
+#include "yagokoro_recognition/image_feature_matching.hpp"
 
 using namespace message_filters::sync_policies;
 
@@ -54,11 +51,7 @@ class FeatureExtraction {
   boost::shared_ptr<ApproximateSync> approximate_sync_;
 
   /// feature extraction
-  cv::Ptr<cv::FeatureDetector> detector_;
-  cv::Ptr<cv::DescriptorExtractor> extractor_;
-
-  std::vector<cv::KeyPoint> keypoints_;
-  cv::Mat descriptors_;
+  ImageFeatureMatchingPtr image_feature_;
 };
 
 }  // namespace

--- a/yagokoro_recognition/include/yagokoro_recognition/image_feature_matching.hpp
+++ b/yagokoro_recognition/include/yagokoro_recognition/image_feature_matching.hpp
@@ -5,6 +5,8 @@
 #include <vector>
 #include <string>
 
+#include <boost/shared_ptr.hpp>
+
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <opencv2/features2d/features2d.hpp>
@@ -14,7 +16,8 @@ namespace yagokoro_recognition {
 
 class ImageFeatureMatching {
  public:
-  ImageFeatureMatching();
+  ImageFeatureMatching(const std::string& detector_type,
+                       const std::string& extractor_type);
   ~ImageFeatureMatching();
 
 
@@ -84,9 +87,9 @@ class ImageFeatureMatching {
   std::vector<cv::Mat> image_vector_;
   std::vector<std::vector<cv::KeyPoint> > keypoints_vector_;
   std::vector<cv::Mat> descriptors_vector_;
-
-
 };
+
+typedef boost::shared_ptr<ImageFeatureMatching> ImageFeatureMatchingPtr;
 
 }  // namespace
 

--- a/yagokoro_recognition/include/yagokoro_recognition/image_feature_matching.hpp
+++ b/yagokoro_recognition/include/yagokoro_recognition/image_feature_matching.hpp
@@ -1,0 +1,93 @@
+#ifndef YAGOKORO_RECOGNITION_IMAGE_FEATURE_MATCHING_HPP_
+#define YAGOKORO_RECOGNITION_IMAGE_FEATURE_MATCHING_HPP_
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/features2d/features2d.hpp>
+#include <opencv2/legacy/legacy.hpp>
+
+namespace yagokoro_recognition {
+
+class ImageFeatureMatching {
+ public:
+  ImageFeatureMatching();
+  ~ImageFeatureMatching();
+
+
+  /// accessors
+  /// @brief set input image
+  void InputImage(const cv::Mat& img) {
+    input_ = img;
+  }
+  /// @brief get input image
+  const cv::Mat& InputImage() {
+    return input_;
+  }
+  /// @brief get keypoints
+  std::vector<cv::KeyPoint>& KeyPoints() {
+    return keypoints_;
+  }
+  /// @brief get descriptors
+  cv::Mat& Descriptors() {
+    return descriptors_;
+  }
+  /// @brief get matching result
+  std::vector<cv::DMatch>& MatchingResult() {
+    return feature_matches_;
+  }
+
+  /// @brief clear feature points table
+  void ClearFeatures() {
+    image_vector_.clear();
+    keypoints_vector_.clear();
+    descriptors_vector_.clear();
+  }
+  /// @brief add current feature points to table
+  void AddCurrentFeatures() {
+    image_vector_.push_back(input_);
+    keypoints_vector_.push_back(keypoints_);
+    descriptors_vector_.push_back(descriptors_);
+  }
+
+
+  /// processing
+  /// @brief detect features
+  void DetectFeatures() {
+    detector_->detect(input_, keypoints_);
+  }
+  /// @brief extract descriptors
+  void ExtractDescriptors() {
+    extractor_->compute(input_, keypoints_, descriptors_);
+  }
+  /// @biref match current features vs feature tables
+  size_t MatchFeatures();
+
+
+ private:
+  cv::Mat input_;
+
+  /// feature detection
+  cv::Ptr<cv::FeatureDetector> detector_;
+  std::vector<cv::KeyPoint> keypoints_;
+
+  /// descriptor extraction
+  cv::Ptr<cv::DescriptorExtractor> extractor_;
+  cv::Mat descriptors_;
+
+  /// matching
+  std::vector<cv::DMatch> feature_matches_;
+  /// for feature points
+  std::vector<cv::Mat> image_vector_;
+  std::vector<std::vector<cv::KeyPoint> > keypoints_vector_;
+  std::vector<cv::Mat> descriptors_vector_;
+
+
+};
+
+}  // namespace
+
+#endif  // YAGOKORO_RECOGNITION_IMAGE_FEATURE_MATCHING_HPP_

--- a/yagokoro_recognition/src/feature_extraction.cpp
+++ b/yagokoro_recognition/src/feature_extraction.cpp
@@ -3,11 +3,8 @@
 namespace yagokoro_recognition {
 
 FeatureExtraction::FeatureExtraction(ros::NodeHandle& n, ros::NodeHandle& np)
-    : n_(n), np_(np), it_(n) {
-  /// feature extractor
-  detector_ = cv::FeatureDetector::create("GridFAST");
-  extractor_ = cv::DescriptorExtractor::create("OpponentBRIEF");
-
+    : n_(n), np_(np), it_(n),
+      image_feature_(new ImageFeatureMatching("GridFAST", "OpponentBRIEF")){
   /// subscriber
   image_transport::TransportHints hints("raw", ros::TransportHints(), np_);
 
@@ -40,11 +37,12 @@ void FeatureExtraction::ImageCallback(
                                  sensor_msgs::image_encodings::BGR8);
     cv_ptr->image.copyTo(image);
 
-    detector_->detect(image, keypoints_);
-    extractor_->compute(image, keypoints_, descriptors_);
+    image_feature_->InputImage(image);
+    image_feature_->DetectFeatures();
+    image_feature_->ExtractDescriptors();
 
     cv::Mat out_image;
-    cv::drawKeypoints(image, keypoints_, out_image);
+    cv::drawKeypoints(image, image_feature_->KeyPoints(), out_image);
     cv::imshow("FeatureExtraction", out_image);
   } catch (cv_bridge::Exception& ex) {
     ROS_ERROR("%s", ex.what());

--- a/yagokoro_recognition/src/image_feature_matching.cpp
+++ b/yagokoro_recognition/src/image_feature_matching.cpp
@@ -1,0 +1,58 @@
+#include "yagokoro_recognition/image_feature_matching.hpp"
+
+namespace yagokoro_recognition {
+
+ImageFeatureMatching::ImageFeatureMatching() {
+}
+ImageFeatureMatching::~ImageFeatureMatching() {
+}
+
+size_t ImageFeatureMatching::MatchFeatures() {
+  size_t n_descriptors = descriptors_vector_.size();
+  std::vector<cv::DMatch> dmatch;
+
+  cv::Ptr<cv::DescriptorMatcher> matcher;
+  if (descriptors_vector_[0].type() == CV_8U) {
+          matcher =
+              new cv::FlannBasedMatcher(
+                  new cv::flann::LshIndexParams(30, 10, 2));
+  } else {
+    matcher = new cv::FlannBasedMatcher();
+  }
+  matcher->add(descriptors_vector_);
+
+  matcher->match(descriptors_, dmatch);
+
+  // counting num of matched features
+  std::vector<size_t> n_matches_list(n_descriptors, 0);
+  for (size_t i = 0; i < dmatch.size(); i++) {
+    int32_t iidx = dmatch[i].imgIdx;
+    if (iidx >= 0 && iidx < n_descriptors) {
+      n_matches_list[iidx]++;
+    }
+  }
+
+  // seeking max num of features
+  int32_t i_max_matches = 0;
+  size_t n_max_matches = n_matches_list[i_max_matches];
+  for (size_t i = 1; i < n_matches_list.size(); i++) {
+    if (n_max_matches < n_matches_list[i]) {
+      i_max_matches = i;
+      n_max_matches = n_matches_list[i];
+    }
+  }
+
+  // writing matched features
+  feature_matches_.clear();
+  for (size_t i = 0; i < dmatch.size(); i++) {
+    int32_t iidx = dmatch[i].imgIdx;
+    if (iidx == i_max_matches) {
+      feature_matches_.push_back(dmatch[i]);
+    }
+  }
+
+  return i_max_matches;
+}
+
+
+}  // namespace

--- a/yagokoro_recognition/src/image_feature_matching.cpp
+++ b/yagokoro_recognition/src/image_feature_matching.cpp
@@ -2,7 +2,11 @@
 
 namespace yagokoro_recognition {
 
-ImageFeatureMatching::ImageFeatureMatching() {
+ImageFeatureMatching::ImageFeatureMatching(
+    const std::string& detector_type = "GridFAST",
+    const std::string& extractor_type = "OpponentBRIEF") {
+  detector_ = cv::FeatureDetector::create(detector_type);
+  extractor_ = cv::DescriptorExtractor::create(extractor_type);
 }
 ImageFeatureMatching::~ImageFeatureMatching() {
 }


### PR DESCRIPTION
Add lib `image_feature_matching` to manage feature detection, descriptor extraction, and feature matching (1vsN), like mARiciten.
Note that this library can be compiled with only OpenCV 2 series,
OpenCV 3 has completely new architecture about image feature.
